### PR TITLE
Fixed clone garden error

### DIFF
--- a/cookie-garden-helper.js
+++ b/cookie-garden-helper.js
@@ -95,7 +95,8 @@ class Garden {
         plot[x][y] = this.minigame.plot[x][y][0];
 
         const seedId = plot[x][y];
-        if (this.getPlant(seedId) && !plant.plantable) {
+        const plant = this.getPlant(seedId);
+        if (plant && !plant.plantable) {
           plot[x][y] = 0;
         }
       }


### PR DESCRIPTION
Refactoring of code resulted in the clone garden function breaking because the plant variable wasn't defined. This patch ensures it's available when testing if a plant exists in the plot.